### PR TITLE
social-network-to-social

### DIFF
--- a/metadata/mainnet/chains.json
+++ b/metadata/mainnet/chains.json
@@ -360,7 +360,7 @@
         "description": "XO is the game changer of next generation social discovery platform. We help GenZ initiate intimate conversations with blockchain-verified identity and AI assistance.",
         "categories": {
           "ai": null,
-          "social-network": null,
+          "social": null,
           "pretge": null
         },
         "added": 1737979094,
@@ -433,7 +433,7 @@
           "infrastructure": null,
           "tools": null,
           "wallet": null,
-          "social-network": null,
+          "social": null,
           "consumer": null,
           "utility": null,
           "RWA": null


### PR DESCRIPTION
In this very small PR, “social-network” was updated to “Social” in two dApps.