### PR TITLE
pixudi-and-navis-war

### DIFF
--- a/metadata/mainnet/chains.json
+++ b/metadata/mainnet/chains.json
@@ -526,7 +526,7 @@
           ]
         },
         "social": {
-          "website": "https://pixudi.com/",
+          "website": "https://game.pixudi.com",
           "x": "https://x.com/thepixudi",
           "telegram": "https://t.me/pixudi",
           "discord": "https://discord.com/invite/W4QGHh9FRX",
@@ -1600,7 +1600,6 @@
           ]
         },
         "social": {
-          "telegram": "https://t.me/naviswargame",
           "discord": "https://discord.com/invite/ujeY9vd5PA"
         }
       },


### PR DESCRIPTION
This PR includes two dApp link updates based on external requests:

- The **Pixudi** website link was updated according to a request from the Pixudi team.

- The **Navis War** Telegram link was removed following instructions from the Marketing team.
