### PR TITLE
Pre-TGE tag removed from one dapp and text for Meson.Fi popular action changed

### DIFF
--- a/metadata/mainnet/chains.json
+++ b/metadata/mainnet/chains.json
@@ -1134,7 +1134,6 @@
         "featured": true,
         "added": 1732625133,
         "categories": {
-          "pretge": null,
           "gaming": [
             "strategy",
             "mobile",

--- a/metadata/mainnet/chains.json
+++ b/metadata/mainnet/chains.json
@@ -15,7 +15,7 @@
         "description": "Swap tokens on Europa Hub using Sushi Swap"
       },
       {
-        "text": "Bridge to Meson.Fi",
+        "text": "Bridge with Meson.Fi",
         "app": "mesonfi",
         "description": "Bridge assets to Meson.Fi"
       }


### PR DESCRIPTION
In this small PR we did some small changes requested by Sawyer:
- We removed Pre-TGE tag from the For Loot And Glory dApp
- We changed the text on Meson.Fi popular action from Bridge "to" Meson.Fi to Bridge "with" Meson.Fi