### PR TITLE
Descriptions added on Testnet for the popular actions dApps

### DIFF
--- a/metadata/testnet/chains.json
+++ b/metadata/testnet/chains.json
@@ -11,11 +11,14 @@
     "actions": [
       {
         "text": "Play Metasoccer",
-        "app": "metasoccer"
+        "app": "metasoccer",
+        "description": "Play MetaSoccer on Nebula Hub"
       },
       {
       "text": "Play Wareden",
-      "app": "wareden"
+      "app": "wareden",
+      "description": "Play Wareden on Nebula Hub"
+
       }
     ],
     "url": "https://nebulachain.io/",
@@ -98,11 +101,13 @@
   "actions": [
     {
       "text": "Swap on Sushi Swap",
-      "app": "sushiswap"
+      "app": "sushiswap",
+      "description": "Swap tokens on Europa Hub using SushiSwap"
     },
     {
     "text": "Bridge to Ruby",
-    "app": "ruby"
+    "app": "ruby",
+    "description": "Bridge tokens to Europa Hub using Ruby Exchange"
     }
   ],
     "url": "https://europahub.network/",
@@ -159,11 +164,13 @@
     "actions": [
       {
         "text": "Use Dmail",
-        "app": "dmail"
+        "app": "dmail",
+        "description": "Use Dmail Network on Calypso Hub"
       },
       {
       "text": "Play Dripverse",
-      "app": "dripverse"
+      "app": "dripverse",
+      "description": "Play Dripverse on Calypso Hub"
       }
     ],
     "url": "https://calypsohub.network/",


### PR DESCRIPTION
In this PR, we fixed the issue with Popular Actions on Testnet. Now, only the intended short description is displayed instead of the full dApp description. This resolves the previous problem where some Popular dApps appeared larger than others due to longer descriptions.
