### PR TITLE
Added short alias to base testnet

### DIFF
--- a/metadata/base-sepolia-testnet/chains.json
+++ b/metadata/base-sepolia-testnet/chains.json
@@ -1,6 +1,7 @@
 {
   "jubilant-horrible-ancha": {
     "alias": "SKALE Base Testnet",
+    "shortAlias": "base-testnet",
     "background": "rgb(0 0 0)",
     "url": "https://skale.space/",
     "description": "",
@@ -9,4 +10,4 @@
     }
   }
 }
-    
+     


### PR DESCRIPTION
In this PR, we added the short alias to base testnet.json since it was missing and needed.