### PR TITLE
Fix chain names - base

### DIFF
--- a/metadata/base-sepolia-testnet/chains.json
+++ b/metadata/base-sepolia-testnet/chains.json
@@ -1,6 +1,6 @@
 {
   "jubilant-horrible-ancha": {
-    "alias": "SKALE Base Testnet",
+    "alias": "SKALE on Base Testnet",
     "shortAlias": "base-testnet",
     "background": "#008a47",
     "gradientBackground": "linear-gradient(#008a47, #006936)",

--- a/metadata/base/chains.json
+++ b/metadata/base/chains.json
@@ -1,6 +1,6 @@
 {
   "bold-ill-informed-jabbah": {
-    "alias": "SKALE Base",
+    "alias": "SKALE on Base",
     "shortAlias": "base",
     "background": "#0000FF",
     "gradientBackground": "linear-gradient(#0000FF, #0000D8)",


### PR DESCRIPTION
This pull request updates chain metadata to clarify the naming of SKALE networks on Base. The main change is a small wording adjustment to the `alias` fields in two metadata files for better clarity.

* Metadata naming update:
  * Changed the `alias` for the Base Testnet chain from "SKALE Base Testnet" to "SKALE on Base Testnet" in `metadata/base-sepolia-testnet/chains.json`.
  * Changed the `alias` for the Base chain from "SKALE Base" to "SKALE on Base" in `metadata/base/chains.json`.