### PR TITLE
Updated the category name from Social Network to Social 

### DIFF
--- a/metadata/mainnet/chains.json
+++ b/metadata/mainnet/chains.json
@@ -165,7 +165,7 @@
         "added": 1758817201,
         "categories": {
           "data-information": null,
-          "social-network": null,
+          "social": null,
           "entertainment": null,
           "consumer": null,
           "defi": [


### PR DESCRIPTION
In this PR, we updated the category name from Social Network to Social for consistency
