### PR TITLE
Update base testnet metadata

### DIFF
--- a/metadata/base-sepolia-testnet/chains.json
+++ b/metadata/base-sepolia-testnet/chains.json
@@ -11,39 +11,13 @@
     },
     "explorerUrl": "https://base-sepolia-testnet-explorer.skalenodes.com/"
   },
-  "miniature-live-tabit": {
-    "alias": "BITE V2 Sandbox",
+  "fancy-this-usable-SKALE": {
+    "alias": "BITE V2 Sandbox ",
     "shortAlias": "bite-v2-sandbox",
     "background": "#FA6944",
     "gradientBackground": "linear-gradient(180deg, #FA6944, #FF5220)",
     "url": "https://skale.space/",
     "description": "BITE v2 Sandbox is a testing environment for the BITE protocol, allowing developers to experiment and build dApps.",
-    "categories": {
-      "sandbox": null,
-      "bite": null
-    },
-    "explorerUrl": "https://base-sepolia-testnet-explorer.skalenodes.com:10012/"
-  },
-  "talkative-victorious-rasalgethi": {
-    "alias": "BITE V2 Sandbox 1",
-    "shortAlias": "bite-v2-sandbox-1",
-    "background": "#FF336D",
-    "gradientBackground": "linear-gradient(180deg, #FF336D, #FF001A)",
-    "url": "https://skale.space/",
-    "description": "BITE v2 Sandbox 1 is a testing environment for the BITE protocol, allowing developers to experiment and build dApps.",
-    "categories": {
-      "sandbox": null,
-      "bite": null
-    },
-    "explorerUrl": "https://base-sepolia-testnet-explorer.skalenodes.com:10022/"
-  },
-  "fancy-this-usable-SKALE": {
-    "alias": "BITE V2 Sandbox 2",
-    "shortAlias": "bite-v2-sandbox-2",
-    "background": "#00B6EF",
-    "gradientBackground": "linear-gradient(180deg, #00B6EF, #0084BF)",
-    "url": "https://skale.space/",
-    "description": "BITE v2 Sandbox 2 is a testing environment for the BITE protocol, allowing developers to experiment and build dApps.",
     "categories": {
       "sandbox": null,
       "bite": null


### PR DESCRIPTION
This pull request updates the `chains.json` configuration for the Base Sepolia testnet by consolidating and renaming sandbox environments related to the BITE V2 protocol. The changes streamline the available sandbox entries and update their identifiers.

Chain configuration updates:

* Renamed the chain key from `miniature-live-tabit` to `fancy-this-usable-SKALE` for the BITE V2 Sandbox entry.
* Removed the `talkative-victorious-rasalgethi` and the previous `fancy-this-usable-SKALE` sandbox entries, consolidating sandbox environments and reducing duplication.