### PR TITLE
Add Ecosystem Background for Testnet in Light Mode

### DIFF
--- a/metadata/testnet/chains.json
+++ b/metadata/testnet/chains.json
@@ -3,7 +3,8 @@
     "alias": "Nebula Gaming Hub",
     "shortAlias": "nebula",
     "background": "#2c1626",
-    "gradientBackground": "linear-gradient(270deg, rgb(67 37 78), rgb(36 32 63))",
+    "gradientBackground": "linear-gradient(270deg, rgb(89 52 102), rgb(47 42 81))",
+    "gradientBackgroundLight": "linear-gradient(270deg, rgb(246 236 255), rgb(207, 222, 255))",
     "categories": {
       "hub": null,
       "gaming": null
@@ -93,7 +94,8 @@
     "alias": "Europa DeFi Hub",
     "shortAlias": "europa",
     "background": "rgb(5 19 37)",
-    "gradientBackground": "linear-gradient(270deg, rgb(5, 19, 37), rgb(13 36 65))",
+    "gradientBackground": "linear-gradient(270deg, rgb(15 41 73), rgb(16 33 55))",
+    "gradientBackgroundLight": "linear-gradient(270deg, rgb(203 226 255), rgb(224 238 255))",
     "categories": {
       "hub": null,
       "defi": null
@@ -156,7 +158,8 @@
     "alias": "Calypso Hub",
     "shortAlias": "calypso",
     "background": "#ce126f",
-    "gradientBackground": "linear-gradient(270deg, rgb(103 35 71), rgb(57 15 68))",
+    "gradientBackground": "linear-gradient(270deg, rgb(128 48 90), rgb(77 23 91))",
+    "gradientBackgroundLight": "linear-gradient(180deg, rgb(255 202 230), rgb(248 222 255))",
     "categories": {
       "hub": null,
       "digital-collectibles": null
@@ -221,7 +224,8 @@
     "alias": "Titan AI Hub",
     "shortAlias": "titan",
     "background": "rgb(50 22 11)",
-    "gradientBackground": "linear-gradient(270deg, rgb(105 50 31), rgb(57 27 17))",
+    "gradientBackground": "linear-gradient(270deg, rgb(116 53 31), rgb(67 28 15))",
+    "gradientBackgroundLight": "linear-gradient(270deg, rgb(255 216 202), rgb(255 234 227))",
     "categories": {
       "hub": null,
       "ai": null


### PR DESCRIPTION
This pull request updates the visual styling for several testnet chains by adjusting their gradient backgrounds and introducing new light gradient backgrounds for improved theming and UI consistency.

Theme updates for testnet chains:

* Updated the `gradientBackground` values for the following chains to use new color schemes for a refreshed look: Nebula Gaming Hub, Europa DeFi Hub, Calypso Hub, and Titan AI Hub. [[1]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL6-R7) [[2]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL96-R98) [[3]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL159-R162) [[4]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL224-R228)
* Added new `gradientBackgroundLight` properties for each of these chains to support light mode or lighter UI themes. [[1]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL6-R7) [[2]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL96-R98) [[3]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL159-R162) [[4]](diffhunk://#diff-ac9f3517dab1a655fced87b3cd561b1ad653e418ad638bc8e79327fca102d11fL224-R228)