### PR TITLE
Update metadata

### DIFF
--- a/metadata/base-sepolia-testnet/chains.json
+++ b/metadata/base-sepolia-testnet/chains.json
@@ -12,7 +12,7 @@
     "explorerUrl": "https://base-sepolia-testnet-explorer.skalenodes.com/"
   },
   "fancy-this-usable-SKALE": {
-    "alias": "SKALEW BITE v2 Sandbox",
+    "alias": "SKALE BITE v2 Sandbox",
     "shortAlias": "bite-v2-sandbox",
     "background": "#FA6944",
     "gradientBackground": "linear-gradient(180deg, #FA6944, #FF5220)",


### PR DESCRIPTION
This pull request makes a minor update to the `chains.json` metadata file, correcting the alias for the SKALE BITE v2 Sandbox network.

* Corrected the `alias` field for the `fancy-this-usable-SKALE` chain from "SKALEW BITE v2 Sandbox" to "SKALE BITE v2 Sandbox" in `metadata/base-sepolia-testnet/chains.json`.