### PR TITLE
update chain name base sandbox

### DIFF
--- a/metadata/base-sepolia-testnet/chains.json
+++ b/metadata/base-sepolia-testnet/chains.json
@@ -12,7 +12,7 @@
     "explorerUrl": "https://base-sepolia-testnet-explorer.skalenodes.com/"
   },
   "fancy-this-usable-SKALE": {
-    "alias": "SKALE BITE v2 Sandbox",
+    "alias": "SKALE Hackathon Sandbox",
     "shortAlias": "bite-v2-sandbox",
     "background": "#FA6944",
     "gradientBackground": "linear-gradient(180deg, #FA6944, #FF5220)",


### PR DESCRIPTION
This pull request makes a small update to the `metadata/base-sepolia-testnet/chains.json` file, changing the alias for the `fancy-this-usable-SKALE` network to better reflect its purpose. The change is minor and does not affect functionality.