### PR TITLE
fix: correct typo in normalize_contract_name for eth_erc20

### DIFF
--- a/packages/ima-artifacts/scripts/prepare.py
+++ b/packages/ima-artifacts/scripts/prepare.py
@@ -29,7 +29,7 @@ def normalize_contract_name(name: str) -> str:
     if name == 'message_proxy_chain':
         return normalize_contract_name('message_proxy_for_schain')
     if name == 'eth_erc20':
-        return 'ErhErc20'
+        return 'EthErc20'
     if 'erc' in name:
         return normalize_contract_name(name.replace('erc', 'e_r_c_'))
     return ''.join([word[0].upper() + word[1:] for word in name.split('_')])


### PR DESCRIPTION
normalize_contract_name() returned ErhErc20 instead of EthErc20 for input eth_erc20 The key eth_erc20_address/eth_erc20_abi exists in real deployment files (e.g. gamesoul-hackathon, staging-v2), so the
contract was exported under the wrong key in generated artifacts.